### PR TITLE
wp_nav_menu filter fix

### DIFF
--- a/content-post.php
+++ b/content-post.php
@@ -14,7 +14,7 @@
         <h1><a href="<?php the_permalink() ?>" rel="bookmark" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a></h1>
         <p class="byline vcard"><?php
             printf(__('<time class="updated" datetime="%1$s" pubdate>%2$s @ %3$s </time>', 'divtruth'), get_the_time('Y-m-j'), get_the_time(get_option('date_format')), get_the_time('g:iA'));
-            printf(__('<span class="tags">%1$s</span', 'divtruth'), get_the_category_list(', '));
+            printf(__('<span class="tags">%1$s</span>', 'divtruth'), get_the_category_list(', '));
         ?></p>
 
     </header> <!-- end article header -->

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -72,7 +72,7 @@ function df_primary_nav($newOptions = array()) {
         'depth'             => 3,
         'fallback_cb'       => 'df_framework_main_nav_cb',
     );
-    wp_nav_menu(array_merge($options, apply_filters( 'df_primary_nav', $newOptions ) ));
+    wp_nav_menu(array_merge(apply_filters( 'df_primary_nav', $newOptions ) ), $options);
 } /* end df_framework primary nav */
 
 function df_top_nav($newOptions = array()) {
@@ -91,7 +91,7 @@ function df_top_nav($newOptions = array()) {
         'depth'             => 3,
         'fallback_cb'       => '__return_false',
     );
-    wp_nav_menu(array_merge($options, apply_filters( 'df_top_nav', $newOptions ) ));
+    wp_nav_menu(array_merge(apply_filters( 'df_top_nav', $newOptions ) ), $options);
 } /* end df_framework main nav */
 
 function df_mobile_nav($newOptions = array()) {
@@ -110,7 +110,7 @@ function df_mobile_nav($newOptions = array()) {
         'depth'             => 2,
         'fallback_cb'       => 'df_framework_mobile_nav_cb'
     );
-    wp_nav_menu(array_merge($options, apply_filters( 'df_mobile_nav', $newOptions ) ));
+    wp_nav_menu(array_merge(apply_filters( 'df_mobile_nav', $newOptions ) ), $options);
 } /* end df_framework mobile nav */
 
 function df_footer_nav($newOptions = array()) {
@@ -128,7 +128,7 @@ function df_footer_nav($newOptions = array()) {
         'depth'             => 1,
         'fallback_cb'       => '__return_false',
     );
-    wp_nav_menu(array_merge($options, apply_filters( 'df_footer_nav', $newOptions ) ));
+    wp_nav_menu(array_merge(apply_filters( 'df_footer_nav', $newOptions ) ), $options);
 } /* end df_framework footer nav */
 
 function df_framework_main_nav_cb(){


### PR DESCRIPTION
- Fixes order of wp_nav_menu options arrays to allow child theme to properly override the parent theme options. 
- Adds a missing > to the span on category tags.
