### PR TITLE
Check if login & admin css files exist before setting a version & enqueueing

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -12,13 +12,17 @@
 
 # Calling your own login css so you can style it
 function df_login_styles() {
-    $version = filemtime(THEME_APPEARANCE_DIR.'css/login.css');
-    wp_enqueue_style( 'theme_login_styles', THEME_APPEARANCE_URL.'css/login.css', false, $version );
+	if( file_exists(THEME_APPEARANCE_DIR.'css/login.css') ) {
+		$version = filemtime( THEME_APPEARANCE_DIR . 'css/login.css' );
+		wp_enqueue_style( 'theme_login_styles', THEME_APPEARANCE_URL . 'css/login.css', false, $version );
+	}
 }
 
 function df_admin_styles() {
-    $version = filemtime(THEME_APPEARANCE_DIR.'css/admin.css');
-    wp_enqueue_style( 'theme_admin_styles', THEME_APPEARANCE_URL.'css/admin.css', false, $version );
+	if( file_exists(THEME_APPEARANCE_DIR.'css/login.css') ) {
+		$version = filemtime( THEME_APPEARANCE_DIR . 'css/admin.css' );
+		wp_enqueue_style( 'theme_admin_styles', THEME_APPEARANCE_URL . 'css/admin.css', false, $version );
+	}
 }
 
 # Calling it only on the login page


### PR DESCRIPTION
When a child theme is missing one or both of those files, a php error was thrown because $version was trying to run a php function on a non-existent file.
